### PR TITLE
[BUGFIX] Fix mapping error with classes not being Documents

### DIFF
--- a/Classes/Radmiraal/CouchDB/Aspect/PersistenceManagerAspect.php
+++ b/Classes/Radmiraal/CouchDB/Aspect/PersistenceManagerAspect.php
@@ -95,9 +95,13 @@ class PersistenceManagerAspect {
 		$object = $joinPoint->getAdviceChain()->proceed($joinPoint);
 
 		if ($object === NULL) {
-			$document = $this->documentManager->find($joinPoint->getMethodArgument('objectType'), $joinPoint->getMethodArgument('identifier'));
-			if ($document !== NULL) {
-				return $document;
+			try {
+				$document = $this->documentManager->find($joinPoint->getMethodArgument('objectType'), $joinPoint->getMethodArgument('identifier'));
+				if ($document !== NULL) {
+					return $document;
+				}
+			} catch (\Doctrine\ODM\CouchDB\Mapping\MappingException $exception) {
+				// probably not a valid document, so ignore it
 			}
 		}
 


### PR DESCRIPTION
When an object is to be fetched but it is not a valid Document
an exception would be thrown. This changes ignores that exception.
