### PR TITLE
using objects in findBy* methods

### DIFF
--- a/Classes/Radmiraal/CouchDB/Persistence/AbstractRepository.php
+++ b/Classes/Radmiraal/CouchDB/Persistence/AbstractRepository.php
@@ -176,7 +176,8 @@ abstract class AbstractRepository implements \TYPO3\Flow\Persistence\RepositoryI
 	 */
 	protected function getQueryMatchValue($value) {
 		if (is_object($value)
-			&& $this->reflectionService->isClassAnnotatedWith(get_class($value), 'TYPO3\Flow\Annotations\Entity')) {
+			&& ($this->reflectionService->isClassAnnotatedWith(get_class($value), 'TYPO3\Flow\Annotations\Entity')
+				|| $this->reflectionService->isClassAnnotatedWith(get_class($value), 'Doctrine\ODM\CouchDB\Mapping\Annotations\Document'))) {
 				return $this->persistenceManager->getIdentifierByObject($value);
 		}
 		return $value;


### PR DESCRIPTION
This change adds functionality for using objects in findBy* findOneBy* methods.

resolves #8